### PR TITLE
010224_Update_ zFnPlane/arc

### DIFF
--- a/cpp/headers/zInterOp/functionSets/zFnArc.h
+++ b/cpp/headers/zInterOp/functionSets/zFnArc.h
@@ -23,7 +23,7 @@
 
 namespace zSpace
 {
-	/** \addtogroup zInterface
+	/** \addtogroup zInterOp
 	*	\brief The Application Program Interface of the library.
 	*  @{
 	*/
@@ -33,7 +33,7 @@ namespace zSpace
 	*  @{
 	*/
 
-	/*! \class zFnNurbsCUrve
+	/*! \class zFnArc
 	*	\brief An arc function set.
 	*	\since version 0.0.4
 	*/
@@ -49,7 +49,7 @@ namespace zSpace
 		//--------------------------
 		//---- PROTECTED ATTRIBUTES
 		//--------------------------
-		/*!	\brief pointer to a graph object  */
+		/*!	\brief pointer to a arc object  */
 		zObjArc *arcObj;
 
 	public:
@@ -64,14 +64,14 @@ namespace zSpace
 
 		/*! \brief Default constructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		zFnArc();
 
 		/*! \brief Overloaded constructor.
 		*
-		*	\param		[in]	_nurbsCurveObj			- input nurbscurve object.
-		*	\since version 0.0.2
+		*	\param		[in]	_arcObj			- input arcObj object.
+		*	\since version 0.0.4
 		*/
 		zFnArc(zObjArc& _arcObj);
 
@@ -82,7 +82,7 @@ namespace zSpace
 
 		/*! \brief Default destructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		~zFnArc();
 
@@ -100,6 +100,13 @@ namespace zSpace
 
 		void to(json& j) override;
 
+#if defined ZSPACE_USD_INTEROP
+
+		void from(UsdPrim& usd, bool staticGeom = false)override;
+
+		void to(UsdPrim& usd)override;
+#endif
+
 		void getBounds(zPoint &minBB, zPoint &maxBB) override;
 
 		void clear() override;
@@ -113,27 +120,27 @@ namespace zSpace
 		*	\param		[in]	_plane		- container of zObjPlane.
 		*	\param		[in]	_radius	    - container of radius.
 		*	\param		[in]	_angle		- container of angle.
-		*  	\return				boolean of success or not
+		*  	\return				bool        - boolean of success or not
 		*	\since version 0.0.4
 		*/
 		bool create(zObjPlane& _plane, double _radius, double _angle = Z_TWO_PI);			
 
 		/*! \brief This method creates a circle through three 3d points.
 		*
-		*	\param		[in]	p0		- container of first point.
-		*	\param		[in]	p1	    - container of second point.
-		*	\param		[in]	p2		- container of third point.
-		*  	\return				boolean of success or not
+		*	\param		[in]	p0		    - container of first point.
+		*	\param		[in]	p1	        - container of second point.
+		*	\param		[in]	p2		    - container of third point.
+		*  	\return				bool        - boolean of success or not
 		*	\since version 0.0.2
 		*/ 
 		bool createFromPoints(zPoint p0, zPoint p1, zPoint p2);
 
 		/*! \brief This method creates a circle from two 3d points and a  tangent at the first point.
 		*
-		*	\param		[in]	p0		- container of first point.
-		*	\param		[in]	t1	    - container of tangent vector of first point.
-		*	\param		[in]	p1		- container of second point.
-		*  	\return				boolean of success or not
+		*	\param		[in]	p0		    - container of first point.
+		*	\param		[in]	t1	        - container of tangent vector of first point.
+		*	\param		[in]	p1		    - container of second point.
+		*  	\return				bool        - boolean of success or not
 		*	\since version 0.0.4
 		*/
 		bool createFromTangent(zPoint p0, zVector t1, zPoint p1);
@@ -145,7 +152,7 @@ namespace zSpace
 		//--------------------------
 		
 		/*! \brief This method returns the number of control vertices of the curve.
-		*	\return				number of control vertices.
+		*	\return				int         - number of control vertices.
 		*	\since version 0.0.4
 		*/
 		int numControlVertices();	
@@ -162,28 +169,28 @@ namespace zSpace
 
 		/*! \brief This method sets curve color to the input color.
 		*
-		*	\param		[in]	_col				- input color.
+		*	\param		[in]	_col		 - input color.
 		*	\since version 0.0.4
 		*/
 		void setArcDisplayColor(zColor _col);
 	
 		/*! \brief This method sets edge weight of the curve to the input weight.
 		*
-		*	\param		[in]	_wt				- input weight.
+		*	\param		[in]	_wt		     - input weight.
 		*	\since version 0.0.4
 		*/
 		void setArcDisplayWeight(double _wt);
 
 		/*! \brief This method sets angle of arc to the input number.
 		*
-		*	\param		[in]	_angle			- input angle between 0 and two PI.
+		*	\param		[in]	_angle		 - input angle between 0 and two PI.
 		*	\since version 0.0.4
 		*/
 		void setAngle(double _angle);
 
 		/*! \brief This method sets radius of arc to the input number.
 		*
-		*	\param		[in]	_radius			- input radius.
+		*	\param		[in]	_radius		 - input radius.
 		*	\since version 0.0.4
 		*/
 		void setRadius(double _radius);
@@ -192,23 +199,22 @@ namespace zSpace
 		//--- COMPUTE METHODS 
 		//--------------------------
 
-		/*! \brief This method computes the points on the curve.
+		/*! \brief This method computes the display points on the arc.
 		*
-		*	\param		[in]	numPoints			- number of points required.
+		*	\param		[in]	numPoints	 - number of display points required, 180 by default.
 		*	\since version 0.0.4
 		*/
 		void computeArcPositions(int numPoints = 180);
 
-		/*! \brief This method computes the points on the curve.
+		/*! \brief This method computes the control points of the arc.
 		*
-		*	\param		[in]	numPoints			- number of points required.
 		*	\since version 0.0.4
 		*/
 		void computeControlPoints();
 
 		/*! \brief This method checks if this arc is a circle.
 		*
-		*	\return			bool				- is circle or not
+		*	\return			bool			 - boolean of isCircle or not
 		*	\since version 0.0.4
 		*/
 		bool isCircle();		
@@ -219,93 +225,98 @@ namespace zSpace
 
 		/*! \brief This method gets the angle of arc.
 		*
-		*	\return			double				- angle of arc
+		*	\return			double			 - angle of arc
 		*	\since version 0.0.4
 		*/
 		double getAngle();
 
+
+		/*! \brief This method gets the Radius of arc.
+		*
+		*	\return			double			 - Radius of arc
+		*	\since version 0.0.4
+		*/
 		double getRadius();
 
 		/*! \brief This method gets pointer to the internal curve positions container.
 		*
-		*	\return				zPoint*					- pointer to internal vertex position container.
+		*	\return				zPoint*		 - pointer to internal vertex position container.
 		*	\since version 0.0.4
 		*/
 		zPoint* getRawControlPoints();
 
 		/*! \brief This method gets pointer to the internal curve positions container.
 		*
-		*	\param		[out]	numPoints				- output number of points in container.
-		*	\return				zPoint*					- pointer to internal vertex position container.
+		*	\param		[out]	numPoints	 - output number of points in container.
+		*	\return				zPoint*		 - pointer to internal vertex position container.
 		*	\since version 0.0.4
 		*/
 		zPoint* getRawArcPositions(int& numPoints);
 
 		/*! \brief This method gets point at the specified parameter value.
 		*
-		*	\param		[in]	t						- parameter value ( between 0 & 1).
-		*	\return				zPoint					- point at parameter value.
+		*	\param		[in]	t			 - parameter value ( between 0 & 1).
+		*	\return				zPoint		 - point at parameter value.
 		*	\since version 0.0.4
 		*/
 		zPoint getPointAt(double t);
 
 		/*! \brief This method gets tangent at the specified parameter value.
 		*
-		*	\param		[in]	t						- parameter value ( between 0 & 1).
-		*	\return				zVector					- tangent at parameter value.
+		*	\param		[in]	t			 - parameter value ( between 0 & 1).
+		*	\return				zVector		 - tangent at parameter value.
 		*	\since version 0.0.4
 		*/
 		zVector getTangentAt(double t);
 
 		/*! \brief This method gets tangent at the specified parameter value.
 		*
-		*	\param		[in]	t						- parameter value ( between 0 & 1).
-		*	\param		[out]	p						- point at parameter value.
-		*	\param		[out]	tan						- tangent at parameter value.
+		*	\param		[in]	t			 - parameter value between 0 & 1.
+		*	\param		[out]	p			 - point at parameter value.
+		*	\param		[out]	tan			 - tangent at parameter value.
 		*	\since version 0.0.4
 		*/
 		void getPointTangentAt(double t, zPoint &p, zVector &tan);
 						
-		/*! \brief This method gets the center the curve.
+		/*! \brief This method gets the center of the arc curve.
 		*
-		*	\return		zPoint					- center .
+		*	\return		zPoint				 - the center of the arc curve.
 		*	\since version 0.0.4
 		*/
 		zPoint getCenter();
 
 		/*! \brief This method gets the length of the curve.
 		*
-		*	\return		double					- length of the curve .
+		*	\return		double				 - length of the arc curve .
 		*	\since version 0.0.4
 		*/
 		double getLength();
 
 		/*! \brief This method gets the domain of the curve.
 		*
-		*	\return		zDomainDouble					- domain of the curve .
+		*	\return		zDomainDouble		 - domain of the curve .
 		*	\since version 0.0.4
 		*/
 		//zDomainDouble getDomain();
 
 		/*! \brief This method gets the knot of the curve.
 		*
-		*	\return		zDoubleArray					- container of knot vector of the curve .
+		*	\return		zDoubleArray		 - container of knot vector of the curve .
 		*	\since version 0.0.4
 		*/
 		//zDoubleArray getKnotVector();
 
 		/*! \brief This method gets the degree of the curve.
 		*
-		*	\return		int					- degree of the curve .
+		*	\return		int					 - degree of the curve.
 		*	\since version 0.0.4
 		*/
 		//int getDegree();
 		
-		/*! \brief This method computes the lengths of all the half edges of a the graph.
+		/*! \brief This method gets the Raw OpenNurbs Arc object.
 		*
-		*	\param		[out]	halfEdgeLengths				- vector of halfedge lengths.
-		*	\return				double						- total edge lengths.
-		*	\since version 0.0.2
+		*	\return		ON_Circle	         - the Raw OpenNurbs Arc object.
+		*	\since version 0.0.4
 		*/
 		ON_Circle* getRawON_Arc();
 

--- a/cpp/headers/zInterOp/functionSets/zFnNurbsCurve.h
+++ b/cpp/headers/zInterOp/functionSets/zFnNurbsCurve.h
@@ -108,6 +108,13 @@ namespace zSpace
 
 		void to(json& j) override;
 
+#if defined ZSPACE_USD_INTEROP
+
+		void from(UsdPrim& usd, bool staticGeom = false)override;
+
+		void to(UsdPrim& usd)override;
+#endif
+
 		void getBounds(zPoint &minBB, zPoint &maxBB) override;
 
 		void clear() override;

--- a/cpp/headers/zInterOp/functionSets/zFnPlane.h
+++ b/cpp/headers/zInterOp/functionSets/zFnPlane.h
@@ -16,12 +16,15 @@
 
 #pragma once
 
+
+#include <headers/zInterface/objects/zObj.h>
+#include <headers/zInterOp/include/zRhinoInclude.h>
 #include<headers/zInterface/functionsets/zFn.h>
 #include<headers/zInterop/objects/zObjPlane.h>
 
 namespace zSpace
 {
-	/** \addtogroup zInterface
+	/** \addtogroup zInterOp
 	*	\brief The Application Program Interface of the library.
 	*  @{
 	*/
@@ -31,7 +34,7 @@ namespace zSpace
 	*  @{
 	*/
 
-	/*! \class zFnNurbsCUrve
+	/*! \class zFnPlane
 	*	\brief An arc function set.
 	*	\since version 0.0.4
 	*/
@@ -48,7 +51,7 @@ namespace zSpace
 		//---- PROTECTED ATTRIBUTES
 		//--------------------------
 
-		/*!	\brief pointer to a graph object  */
+		/*!	\brief pointer to a zObjPlane object  */
 		zObjPlane *planeObj;	
 
 	public:
@@ -63,14 +66,14 @@ namespace zSpace
 
 		/*! \brief Default constructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		zFnPlane();
 
 		/*! \brief Overloaded constructor.
 		*
-		*	\param		[in]	_nurbsCurveObj			- input nurbscurve object.
-		*	\since version 0.0.2
+		*	\param		[in]	_planeObj			- input zObjPlane object.
+		*	\since version 0.0.4
 		*/
 		zFnPlane(zObjPlane& _planeObj);
 
@@ -81,7 +84,7 @@ namespace zSpace
 
 		/*! \brief Default destructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		~zFnPlane();
 
@@ -99,6 +102,13 @@ namespace zSpace
 
 		void to(json& j) override;
 
+#if defined ZSPACE_USD_INTEROP
+
+		void from(UsdPrim& usd, bool staticGeom = false)override;
+
+		void to(UsdPrim& usd)override;
+#endif
+
 		void getBounds(zPoint &minBB, zPoint &maxBB) override;
 
 		void clear() override;
@@ -107,19 +117,42 @@ namespace zSpace
 		//---- CREATE METHODS
 		//--------------------------
 
-		/*! \brief This method creates a graph from the input containers.
+		/*! \brief This method creates a graph from the input origin, xAxis, yAxis containers.
 		*
-		*	\param		[in]	_positions		- container of type zPoint containing control point positions.
-		*	\param		[in]	edgeConnects	- container of edge connections with vertex ids for each edge
-		*	\param		[in]	staticGraph		- makes the graph fixed. Computes the static edge vertex positions if true.
-		*	\since version 0.0.2
+		*	\param		[in]	origin		- container of input origin, zPoint(0,0,0) by default.
+		*	\param		[in]	xAxis	    - container of input xAxis, zVector(1,0,0) by default.
+		*	\param		[in]	yAxis		- container of input yAxis, zVector(0,1,0) by default.
+		* 	\return		        bool		- boolean of success or not
+		*	\since version 0.0.4
 		*/
 		bool create(zPoint origin = zPoint(0,0,0), zVector xAxis = zVector(1,0,0), zVector yAxis = zVector(0,1,0));
 
+		/*! \brief This method creates a graph from the input origin, xAxis, yAxis containers.
+		*
+		*	\param		[in]	_plane		- container of input Eigen::Matrix4f.
+		*   \return		        bool		- boolean of success or not
+		*	\since version 0.0.4
+		*/
 		bool createFromMatrix(Eigen::Matrix4f & _plane);
 
+		/*! \brief This method creates a graph from the input origin, xAxis, yAxis containers.
+		*
+		*	\param		[in]	origin		- container of input origin.
+		* 	\param		[in]	normal		- container of input normal vector.
+		* 	\param		[in]	yUp		    - container of input yUp vector, zVector(0,1,0) by default.
+		*   \return		        bool		- boolean of success or not
+		*	\since version 0.0.4
+		*/
 		bool createFromNormal(zPoint origin, zVector normal, zVector yUp = zVector(0,1,0));
 
+		/*! \brief This method creates a graph from the input 3 points position.
+		*
+		*	\param		[in]	p0			- container of point 0, used as origin of plane.
+		*	\param		[in]	p1	    	- container of point 1, used as xAxis direction.
+		*	\param		[in]	p2			- container of point 2, used as yAxis direction.
+		*   \return		        bool		- boolean of success or not
+		*	\since version 0.0.4
+		*/
 		bool createFromPoints(zPoint p0, zPoint p1, zPoint p2);				
 
 		//--------------------------
@@ -138,45 +171,73 @@ namespace zSpace
 
 		/*! \brief This method sets curve color to the input color.
 		*
-		*	\param		[in]	_col				- input color.
-		*	\since version 0.0.2
+		*	\param		[in]	xCol				- input color of xAxis, zColor(1.0, 0.0, 0.0, 1.0) by default.
+		*   \param		[in]	yCol				- input color of yAxis, zColor(0.0, 1.0, 0.0, 1.0) by default.
+		*   \param		[in]	zCol				- input color of zAxis, zColor(0.0, 0.0, 1.0, 1.0) by default.
+		*	\since version 0.0.4
 		*/
-		void setDisplayColor(zColor xCol, zColor yCol, zColor zCol);
+		void setDisplayColor(zColor xCol = zColor(1.0, 0.0, 0.0, 1.0), zColor yCol = zColor(0.0, 1.0, 0.0, 1.0), zColor zCol = zColor(0.0, 0.0, 1.0, 1.0));
 
 	
-		/*! \brief This method sets edge weight of the curve to the input weight.
+		/*! \brief This method sets Display Weight of plane.
 		*
-		*	\param		[in]	_wt				- input weight.
-		*	\since version 0.0.2
+		*	\param		[in]	_wt				     - input Display Weight of plane.
+		*	\since version 0.0.4
 		*/
 		void setDisplayWeight(double _wt);
 
+		/*! \brief This method sets origin position of the plane.
+		*
+		*	\param		[in]	origin				 - input origin position.
+		*	\since version 0.0.4
+		*/
 		void setOrigin(zPoint origin);
 
+		/*! \brief This method sets xAxis, yAxis and noral of the plane.
+		*
+		*	\param		[in]	xAxis				 - input xAxis vector.
+		*   \param		[in]	yAxis				 - input yAxis vector.
+		*   \param		[in]	normal				 - input normal vector.
+		*	\since version 0.0.4
+		*/
 		void setAxis(zVector xAxis, zVector yAxis, zVector normal);
 
 		//--------------------------
 		//--- GET METHODS 
 		//--------------------------
 
-		/*! \brief This method gets the center the curve.
+		/*! \brief This method gets the origin the plane.
 		*
-		*	\return		zPoint					- center .
+		*	\return		zPoint					     - origin of the plane.
 		*	\since version 0.0.4
 		*/
 		zPoint getOrigin();
 
+		/*! \brief This method gets the xAxis the plane.
+		*
+		*	\return		zPoint					     - xAxis of the plane.
+		*	\since version 0.0.4
+		*/
 		zVector getXAxis();
 
+		/*! \brief This method gets the yAxis the plane.
+		*
+		*	\return		zPoint					     - yAxis of the plane.
+		*	\since version 0.0.4
+		*/
 		zVector getYAxis();
 
+		/*! \brief This method gets the Normal the plane.
+		*
+		*	\return		zPoint					     - Normal of the plane.
+		*	\since version 0.0.4
+		*/
 		zVector getNormal();
 		
-		/*! \brief This method computes the lengths of all the half edges of a the graph.
+		/*! \brief This method gets the Raw OpenNurbs Plane object.
 		*
-		*	\param		[out]	halfEdgeLengths				- vector of halfedge lengths.
-		*	\return				double						- total edge lengths.
-		*	\since version 0.0.2
+		*	\return				ON_Plane			-  Raw OpenNurbs Plane object.
+		*	\since version 0.0.4
 		*/
 		ON_Plane* getRawON_Plane();
 

--- a/cpp/headers/zInterOp/objects/zObjArc.h
+++ b/cpp/headers/zInterOp/objects/zObjArc.h
@@ -25,7 +25,7 @@
 
 namespace zSpace
 {
-	/** \addtogroup zInterface
+	/** \addtogroup zInterOp
 	*	\brief The Application Program Interface of the library.
 	*  @{
 	*/
@@ -35,8 +35,8 @@ namespace zSpace
 	*  @{
 	*/
 
-	/*! \class zObjNurbsCurve
-	*	\brief The nurbs curve object class using OpenNURBS
+	/*! \class zObjArc
+	*	\brief The arc object class using OpenNURBS
 	*	\details https://github.com/mcneel/opennurbs
 	*	\since version 0.0.4
 	*/
@@ -93,7 +93,7 @@ namespace zSpace
 		zColor controlPolyColor = zColor(0, 0, 1, 0);
 
 		/*!	\brief container which stores weights of arc points.	 */
-		double controlPointWeight = 5;
+		double controlPointsWeight = 5;
 
 		/*!	\brief container which stores weights of arc points.	 */
 		double controlPolyWeight = 1;
@@ -104,13 +104,13 @@ namespace zSpace
 		/*!	\brief container which stores positions of arc for display.			*/
 		zPointArray arcPositions;
 
-		/*!	\brief stores color of the arc.			*/
+		/*!	\brief stores display color of the arc.	 */
 		zColor arcDisplayColor = zColor(1, 0, 0, 0);
 
-		/*!	\brief stores weight of the arc.			*/
+		/*!	\brief stores weight of the arc. */
 		double arcDisplayWeight = 3;
 
-		/*!	\brief OpenNURBS curve	*/
+		/*!	\brief OpenNURBS arc object	*/
 		ON_Arc on_arc;
 
 		//--------------------------
@@ -119,7 +119,7 @@ namespace zSpace
 
 		/*! \brief Default constructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		zObjArc();
 
@@ -129,7 +129,7 @@ namespace zSpace
 
 		/*! \brief Default destructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		~zObjArc();
 
@@ -137,14 +137,50 @@ namespace zSpace
 		//---- SET METHODS
 		//--------------------------
 
-		/*! \brief This method sets display vertices, edges and face booleans.
+		/*! \brief This method sets display arc, Control Points and Plane booleans.
 		*
-		*	\param		[in]	_displayControlPoints		- input display controlPoints booelan.
-		*	\param		[in]	_displayCurve				- input display curve booelan.
-		*	\since version 0.0.2
+		*	\param		[in]	_displayArc		            - input display arc booelan.
+		*	\param		[in]	_displayControlPoints		- input display Control Points booelan.
+		*   \param		[in]	_displayPlane				- input display Plane booelan.
+		*	\since version 0.0.4
 		*/
 		void setDisplayElements(bool _displayArc, bool _displayControlPoints, bool _displayPlane);
 
+
+		/*! \brief This method sets display arc color.
+		*
+		*	\param		[in]	_arcDisplayColor		    - input display arc color.
+		*	\since version 0.0.4
+		*/
+		void setArcDisplayColor(zColor _arcDisplayColor);
+
+		/*! \brief This method sets display control Points Color.
+		*
+		*	\param		[in]	_controlPointsColor		    - input display control Points Color.
+		*	\since version 0.0.4
+		*/
+		void setControlPointsColor(zColor _controlPointsColor);
+
+		/*! \brief This method sets display control Poly Color.
+		*
+		*	\param		[in]	_controlPolyColor		    - input control Poly Color.
+		*	\since version 0.0.4
+		*/
+		void setControlPolyColor(zColor _controlPolyColor);
+
+		/*! \brief This method sets display control Points Weight.
+		*
+		*	\param		[in]	_controlPointsColor		    - input display control Points Weight.
+		*	\since version 0.0.4
+		*/
+		void setControlPointsWeight(double _controlPointsWeight);
+
+		/*! \brief This method sets display control Poly Weight.
+		*
+		*	\param		[in]	_controlPolyColor		    - input control Poly Weight.
+		*	\since version 0.0.4
+		*/
+		void setControlPolyWeight(double _controlPolyWeight);
 
 		//--------------------------
 		//---- GET METHODS
@@ -171,6 +207,28 @@ namespace zSpace
 		*/
 		int getVBO_CurveColorId();
 
+		/*! \brief This method gets Raw radius vector of the arc.
+		*
+		*	\param		[out]	_Normal	         - stores Raw radius vector of the arc.
+		*	\since version 0.0.4
+		*/
+		void getRawRadius(double _radius);
+
+		/*! \brief This method gets Raw Angle in radian of the arc.
+		*
+		*	\param		[out]	_Normal	         - stores Raw Angle in radian of the arc.
+		*	\since version 0.0.4
+		*/
+		void getRawAngleRadian(double _angle);
+
+		/*! \brief This method gets Raw plane of the arc.
+		*
+		*	\param		[out]	_Normal	         - stores Raw plane of the arc.
+		*	\since version 0.0.4
+		*/
+		void getRawPlane(zObjPlane _oPlane);
+
+
 		//--------------------------
 		//---- OVERRIDE METHODS
 		//--------------------------
@@ -189,7 +247,7 @@ namespace zSpace
 
 		/*! \brief This method appends graph to the buffer.
 		*
-		*	\since version 0.0.1
+		*	\since version 0.0.4
 		*/
 		void appendToBuffer();
 
@@ -198,9 +256,9 @@ namespace zSpace
 		//---- PROTECTED DISPLAY METHODS
 		//--------------------------
 
-		/*! \brief This method displays the zGraph.
+		/*! \brief This method displays the zObjArc.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		void drawArc();
 	};

--- a/cpp/headers/zInterOp/objects/zObjCurve.h
+++ b/cpp/headers/zInterOp/objects/zObjCurve.h
@@ -1,0 +1,310 @@
+// This file is part of zspace, a simple C++ collection of geometry data-structures & algorithms, 
+// data analysis & visualization framework.
+//
+// Copyright (C) 2023 ZSPACE 
+// 
+// This Source Code Form is subject to the terms of the MIT License 
+// If a copy of the MIT License was not distributed with this file, You can 
+// obtain one at https://opensource.org/licenses/MIT.
+//
+// AAuthor : Ling Mao <Ling.Mao@zaha-hadid.com>
+//
+
+#ifndef ZSPACE_OBJ_CURVE_H
+#define ZSPACE_OBJ_CURVE_H
+
+#pragma once
+
+#include <headers/zInterface/objects/zObj.h>
+#include <headers/zInterOp/include/zRhinoInclude.h>
+
+#include <vector>
+//using namespace std;
+
+namespace zSpace
+{
+	/** \addtogroup zInterface
+	*	\brief The Application Program Interface of the library.
+	*  @{
+	*/
+
+	/** \addtogroup zObjects
+	*	\brief The object classes of the library.
+	*  @{
+	*/
+
+	/*! \class zObjNurbsCurve
+	*	\brief The nurbs curve object class using OpenNURBS
+	*	\details https://github.com/mcneel/opennurbs
+	*	\since version 0.0.4
+	*/
+
+	/** @}*/
+	
+	/** @}*/
+
+	class ZSPACE_API zObjCurve : public zObj
+	{
+	private:
+		/*! \brief boolean for displaying the vertices */
+		bool displayControlPoints;
+
+		/*! \brief boolean for displaying the edges */
+		bool displayCurve;
+
+		/*!	\brief stores the start vertex ID in the VBO, when attached to the zBufferObject.	*/
+		int VBO_ControlPointId;
+
+		/*!	\brief stores the start edge ID in the VBO, when attached to the zBufferObject.	*/
+		int VBO_CurvePointId;
+
+		/*!	\brief stores the start vertex color ID in the VBO, when attache to the zBufferObject.	*/
+		int VBO_CurveColorId;		
+
+	protected:
+		
+		/*!	\brief number of display positions.			*/
+		int numDisplayPositions;
+
+		/*!	\brief container which stores positions of curve points for display.			*/
+		zPointArray displayPositions;
+
+		/*!	\brief container which stores positions of curve control points.			*/
+		zPointArray displayControlPointPositions;
+
+		/*!	\brief stores color of the curve.			*/
+		zColor displayColor;
+
+		/*!	\brief stores weight of the curve.			*/
+		double displayWeight;
+
+		/*!	\brief stores dimension of the curve.			*/
+		int degree;
+
+		/*!	\brief stores periodic of the curve.			*/
+		bool periodic;
+
+
+	public:
+		//--------------------------
+		//---- PUBLIC ATTRIBUTES
+		//--------------------------
+		
+		/*!	\brief OpenNURBS curve			*/
+		ON_Curve on_curve;
+
+		//--------------------------
+		//---- CONSTRUCTOR
+		//--------------------------
+
+		/*! \brief Default constructor.
+		*
+		*	\since version 0.0.2
+		*/
+		zObjCurve();
+
+		//--------------------------
+		//---- DESTRUCTOR
+		//--------------------------
+
+		/*! \brief Default destructor.
+		*
+		*	\since version 0.0.2
+		*/
+		~zObjCurve();
+
+		//--------------------------
+		//---- SET METHODS
+		//--------------------------
+
+		/*! \brief This method sets display vertices, edges and face booleans.
+		*
+		*	\param		[in]	_displayControlPoints		- input display controlPoints booelan.
+		*	\param		[in]	_displayCurve				- input display curve booelan.
+		*	\since version 0.0.2
+		*/
+		void setDisplayElements(bool _displayControlPoints, bool _displayCurve);
+
+		/*! \brief This method sets display vertex positions.
+		*
+		*	\param		[in]	_positions		- input display on curve positions.
+		*	\since version 0.0.2
+		*/
+		void setDisplayPositions(zPointArray& _positions);
+
+		/*! \brief This method sets curve degree.
+		*
+		*	\param		[in]	_degree		- input curve degree.
+		*	\since version 0.0.2
+		*/
+		void setDegree(int _degree);
+
+		/*! \brief This method sets curve periodic.
+		*
+		*	\param		[in]	_degree		- input curve periodic.
+		*	\since version 0.0.2
+		*/
+		void setPeriodic(bool _periodic);
+
+		/*! \brief This method sets curve display color.
+		*
+		*	\param		[in]	_displayColor		- input display color.
+		*	\since version 0.0.2
+		*/
+		void setDisplayColor(zColor _displayColor);
+
+		/*! \brief This method sets curve display weight.
+		*
+		*	\param		[in]	_displayColor		- input display weight.
+		*	\since version 0.0.2
+		*/
+		void setDisplayWeight(double _displayWeight);
+
+		/*! \brief This method sets curve control points.
+		*
+		*	\param		[in]	_controlPoints		- input curve control points.
+		*	\since version 0.0.2
+		*/
+		void setDisplayControlPoints(zPointArray& _displayControlPoints);
+
+		/*! \brief This method sets curve control point weights.
+		*
+		*	\param		[in]	_controlPointWeights		- input curve control point weights.
+		*	\since version 0.0.2
+		*/
+		void setControlPointWeights(zDoubleArray& _controlPointWeights);
+
+		//--------------------------
+		//---- GET METHODS
+		//--------------------------
+
+		/*! \brief This method gets display vertex positions.
+		*
+		*	\param		[out]	_positions		- output display on curve positions.
+		*	\since version 0.0.2
+		*/
+		void getDisplayPositions(zPointArray& _positions);
+
+		/*! \brief This method gets number of display vertex positions.
+		*
+		*	\return			int				- num display positions.
+		*	\since version 0.0.2
+		*/
+		int getNumDisplayPositions();
+
+		/*! \brief This method gets the vertex VBO Index .
+		*
+		*	\return			int				- vertex VBO Index.
+		*	\since version 0.0.2
+		*/
+		int getVBO_ControlPointId();
+
+		/*! \brief This method gets the edge VBO Index .
+		*
+		*	\return			int				- edge VBO Index.
+		*	\since version 0.0.2
+		*/
+		int getVBO_CurvePointId();
+
+		/*! \brief This method gets the vertex color VBO Index .
+		*
+		*	\return			int				- vertex color VBO Index.
+		*	\since version 0.0.2
+		*/
+		int getVBO_CurveColorId();
+
+		/*! \brief This method gets curve dimension.
+		*
+		*	\return			int				- curve degree.
+		*	\since version 0.0.2
+		*/
+		int getDegree();
+
+		/*! \brief This method gets curve periodic.
+		*
+		*	\return			bool				- is periodic or not.
+		*	\since version 0.0.2
+		*/
+		bool isPeriodic();
+
+		//--------------------------
+		//---- OVERRIDE METHODS
+		//--------------------------
+
+#if defined (ZSPACE_UNREAL_INTEROP) || defined (ZSPACE_MAYA_INTEROP) /*|| defined (ZSPACE_RHINO_INTEROP)*/
+		// Do Nothing
+#else
+		void draw() override;
+#endif
+
+		void getBounds(zPoint &minBB, zPoint &maxBB) override;
+
+		//--------------------------
+		//---- DISPLAY BUFFER METHODS
+		//--------------------------
+
+		/*! \brief This method appends graph to the buffer.
+		*
+		*	\since version 0.0.1
+		*/
+		void appendToBuffer();
+
+	protected:
+		//--------------------------
+		//---- PROTECTED DISPLAY METHODS
+		//--------------------------
+
+		/*! \brief This method displays the zGraph.
+		*
+		*	\since version 0.0.2
+		*/
+		void drawNurbsCurve();
+	};
+
+	/** \addtogroup zCore
+	*	\brief The core datastructures of the library.
+	*  @{
+	*/
+
+	/** \addtogroup zBase
+	*	\brief  The base classes, enumerators ,defintions of the library.
+	*  @{
+	*/
+
+	/** \addtogroup zTypeDefs
+	*	\brief  The type defintions of the library.
+	*  @{
+	*/
+
+	/** \addtogroup Container
+	*	\brief  The container typedef of the library.
+	*  @{
+	*/
+
+	/*! \typedef zObjNurbsCurveArray
+	*	\brief A vector of zObjNurbsCurve.
+	*
+	*	\since version 0.0.4
+	*/
+	typedef vector<zObjCurve> zObjNurbsCurveArray;
+
+	/*! \typedef zObjNurbsCurvePointerArray
+	*	\brief A vector of zObjNurbsCurve pointers.
+	*
+	*	\since version 0.0.4
+	*/
+	typedef vector<zObjCurve*>zObjNurbsCurvePointerArray;
+
+	/** @}*/
+	/** @}*/
+	/** @}*/
+	/** @}*/
+}
+
+#if defined(ZSPACE_STATIC_LIBRARY)  || defined(ZSPACE_DYNAMIC_LIBRARY)
+// All defined OK so do nothing
+#else
+#include<source/zInterOp/objects/zObjCurve.cpp>
+#endif
+
+#endif

--- a/cpp/headers/zInterOp/objects/zObjPlane.h
+++ b/cpp/headers/zInterOp/objects/zObjPlane.h
@@ -23,7 +23,7 @@
 
 namespace zSpace
 {
-	/** \addtogroup zInterface
+	/** \addtogroup zInterOp
 	*	\brief The Application Program Interface of the library.
 	*  @{
 	*/
@@ -33,8 +33,8 @@ namespace zSpace
 	*  @{
 	*/
 
-	/*! \class zObjNurbsCurve
-	*	\brief The nurbs curve object class using OpenNURBS
+	/*! \class zObjPlane
+	*	\brief The plane object class using OpenNURBS
 	*	\details https://github.com/mcneel/opennurbs
 	*	\since version 0.0.4
 	*/
@@ -52,8 +52,7 @@ namespace zSpace
 	public:
 		//--------------------------
 		//---- PUBLIC ATTRIBUTES
-		//--------------------------		 
-		// move all of the below to private after testing !!!
+		//--------------------------
 
 		/*! \brief boolean for displaying the Axis. */
 		bool displayAxis = true;
@@ -76,7 +75,7 @@ namespace zSpace
 		/*!	\brief stores yAxis of the plane. */
 		zVector yAxis = zVector(0, 1, 0);
 
-		/*!	\brief stores zAxis of the plane. */
+		/*!	\brief stores normal of the plane. */
 		zVector normal = zVector(0, 0, 1);
 
 		/*!	\brief stores color of the axis. */
@@ -85,7 +84,7 @@ namespace zSpace
 		/*!	\brief stores weight of the axis. */
 		double displayWeight = 3;
 
-		/*!	\brief OpenNURBS curve			*/
+		/*!	\brief OpenNURBS plane object. */
 		ON_Plane on_plane;
 
 		//--------------------------
@@ -94,7 +93,7 @@ namespace zSpace
 
 		/*! \brief Default constructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		zObjPlane();
 
@@ -104,31 +103,76 @@ namespace zSpace
 
 		/*! \brief Default destructor.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		~zObjPlane();
-
-
 
 		//--------------------------
 		//---- SET METHODS
 		//--------------------------
 
-		/*! \brief This method sets display vertices, edges and face booleans.
+		/*! \brief This method sets display Axis and Rectangle plane booleans and scales.
 		*
-		*	\param		[in]	_displayControlPoints		- input display controlPoints booelan.
-		*	\param		[in]	_displayCurve				- input display curve booelan.
-		*	\since version 0.0.2
+		*	\param		[in]	_displayAxis		        - input display Axis booelan.
+		*	\param		[in]	_displayRectangle			- input display Rectangle booelan.
+		*   \param		[in]	_displayAxisScale		    - input display Axis Scale.
+		*	\param		[in]	_displayRectangleScale		- input display Rectangle Scale.
+		*	\since version 0.0.4
 		*/
 		void setDisplayElements(bool _displayAxis, bool _displayRectangle, double _displayAxisScale, double _displayRectangleScale);
 
+		/*! \brief This method sets display color array.
+		*
+		*	\param		[in]	_displayColorArray		    - input display Axis booelan.
+		*   \since version 0.0.4
+		*/
+		void setDisplayColor(zColorArray _displayColorArray);
 
 		//--------------------------
 		//---- GET METHODS
 		//--------------------------
+
+		/*! \brief This method gets a 4x4 Matrix of the plane.
+		*	\return				zPlane				- a 4x4 Matrix of the plane.
+		*	\since version 0.0.4
+		*/
 		zPlane getPlaneMatrix();
 		
+		/*! \brief This method gets a Double Array of the plane.
+		*	\return				zDoubleArray		- a Double Array of the plane.
+		*	\since version 0.0.4
+		*/
 		zDoubleArray getDoubleArray();
+
+
+		/*! \brief This method stores Raw Origin of the plane.
+		*
+		*	\param		[out]	_origin	        - stores Raw Origin of the plane.
+		*	\since version 0.0.4
+		*/
+		void getRawOrigin(zPoint &_origin);
+
+		/*! \brief This method stores Raw xAxis vector of the plane.
+		*
+		*	\param		[out]	_xAxis      	- stores Raw xAxis vector of the plane.
+		*	\since version 0.0.4
+		*/
+		void getRawXAxis(zVector& _xAxis);
+
+		/*! \brief This method stores Raw yAxis vector of the plane.
+		*
+		*	\param		[out]	_yAxis	        - stores Raw yAxis vector of the plane.
+		*	\since version 0.0.4
+		*/
+		void getRawYAxis(zVector& _yAxis);
+
+		/*! \brief This method stores Raw Normal vector of the plane.
+		*
+		*	\param		[out]	_Normal	         - stores Raw Normal vector of the plane.
+		*	\since version 0.0.4
+		*/
+		void getRawNormal(zVector& _Normal);
+
 		//--------------------------
 		//---- OVERRIDE METHODS
 		//--------------------------
@@ -145,9 +189,9 @@ namespace zSpace
 		//---- DISPLAY BUFFER METHODS
 		//--------------------------
 
-		/*! \brief This method appends graph to the buffer.
+		/*! \brief This method appends zObjPlane to the buffer.
 		*
-		*	\since version 0.0.1
+		*	\since version 0.0.4
 		*/
 		void appendToBuffer();
 
@@ -156,9 +200,9 @@ namespace zSpace
 		//---- PROTECTED DISPLAY METHODS
 		//--------------------------
 
-		/*! \brief This method displays the zGraph.
+		/*! \brief This method displays the zObjPlane.
 		*
-		*	\since version 0.0.2
+		*	\since version 0.0.4
 		*/
 		void drawPlane();
 	};

--- a/cpp/source/zInterOp/functionSets/zFnArc.cpp
+++ b/cpp/source/zInterOp/functionSets/zFnArc.cpp
@@ -159,6 +159,18 @@ namespace zSpace
 		*/
 	}
 
+#if defined ZSPACE_USD_INTEROP
+
+	ZSPACE_INLINE void zFnArc::from(UsdPrim& usd, bool staticGeom)
+	{
+	}
+
+	ZSPACE_INLINE void zFnArc::to(UsdPrim& usd)
+	{
+	}
+
+#endif
+
 	ZSPACE_INLINE void zFnArc::getBounds(zPoint &minBB, zPoint &maxBB)
 	{
 		arcObj->getBounds(minBB, maxBB);

--- a/cpp/source/zInterOp/functionSets/zFnNurbsCurve.cpp
+++ b/cpp/source/zInterOp/functionSets/zFnNurbsCurve.cpp
@@ -144,6 +144,18 @@ namespace zSpace
 		
 	}
 
+#if defined ZSPACE_USD_INTEROP
+
+	ZSPACE_INLINE void zFnNurbsCurve::from(UsdPrim& usd, bool staticGeom)
+	{
+	}
+
+	ZSPACE_INLINE void zFnNurbsCurve::to(UsdPrim& usd)
+	{
+	}
+
+#endif
+
 	ZSPACE_INLINE void zFnNurbsCurve::getBounds(zPoint &minBB, zPoint &maxBB)
 	{
 		nurbsCurveObj->getBounds(minBB, maxBB);

--- a/cpp/source/zInterOp/functionSets/zFnPlane.cpp
+++ b/cpp/source/zInterOp/functionSets/zFnPlane.cpp
@@ -19,13 +19,13 @@ namespace zSpace
 
 	ZSPACE_INLINE zFnPlane::zFnPlane()
 	{
-		fnType = zFnType::zArcFn;
+		fnType = zFnType::zPlaneFn;
 		planeObj = nullptr;
 	}
 
 	ZSPACE_INLINE zFnPlane::zFnPlane(zObjPlane& _planeObj)
 	{
-		fnType = zFnType::zArcFn;
+		fnType = zFnType::zPlaneFn;
 		planeObj = &_planeObj;
 	}
 
@@ -37,7 +37,7 @@ namespace zSpace
 	
 	ZSPACE_INLINE zFnType zFnPlane::getType()
 	{
-		return zArcFn;
+		return zPlaneFn;
 	}
 
 	
@@ -163,6 +163,18 @@ namespace zSpace
 		//
 	}
 
+#if defined ZSPACE_USD_INTEROP
+
+	ZSPACE_INLINE void zFnPlane::from(UsdPrim& usd, bool staticGeom)
+	{
+	}
+
+	ZSPACE_INLINE void zFnPlane::to(UsdPrim& usd)
+	{
+	}
+
+#endif
+
 	ZSPACE_INLINE void zFnPlane::getBounds(zPoint &minBB, zPoint &maxBB)
 	{
 		planeObj->getBounds(minBB, maxBB);
@@ -182,9 +194,13 @@ namespace zSpace
 		xAxis.normalize();
 		yAxis.normalize();
 
-		if (xAxis == yAxis || xAxis.length() * xAxis.length() == 0)
+		if (xAxis.length() == 0 || yAxis.length() == 0)
 		{
-			return success;
+			return success = false;
+		}
+		else if ((xAxis - yAxis).length() == 0 || (xAxis + yAxis).length() == 0)
+		{
+			return success = false;
 		}
 		else
 		{
@@ -225,10 +241,14 @@ namespace zSpace
 
 		normal.normalize();
 		yUp.normalize();
-
-		if (normal == yUp || normal.length() * yUp.length() == 0)
+		
+		if (normal.length() == 0 || yUp.length() == 0)
 		{
-			return success;
+			return success = false;
+		}
+		else if ((normal - yUp).length() == 0 || (normal + yUp).length() == 0)
+		{
+			return success = false;
 		}
 		else
 		{

--- a/cpp/source/zInterOp/objects/zObjArc.cpp
+++ b/cpp/source/zInterOp/objects/zObjArc.cpp
@@ -45,6 +45,31 @@ namespace zSpace
 		displayPlane = _displayPlane;
 	}
 
+	ZSPACE_INLINE void zObjArc::setArcDisplayColor(zColor _arcDisplayColor)
+	{
+		arcDisplayColor = _arcDisplayColor;
+	}
+
+	ZSPACE_INLINE void zObjArc::setControlPointsColor(zColor _controlPointsColor)
+	{
+		controlPointsColor = _controlPointsColor;
+	}
+
+	ZSPACE_INLINE void zObjArc::setControlPolyColor(zColor _controlPolyColor)
+	{
+		controlPolyColor = _controlPolyColor;
+	}
+
+	ZSPACE_INLINE void zObjArc::setControlPointsWeight(double _controlPointsWeight)
+	{
+		controlPointsWeight = _controlPointsWeight;
+	}
+
+	ZSPACE_INLINE void zObjArc::setControlPolyWeight(double _controlPolyWeight)
+	{
+		controlPolyWeight = _controlPolyWeight;
+	}
+
 	//---- GET METHODS
 
 	ZSPACE_INLINE int zObjArc::getVBO_ControlPointId()
@@ -60,6 +85,21 @@ namespace zSpace
 	ZSPACE_INLINE int zObjArc::getVBO_CurveColorId()
 	{
 		return VBO_CurveColorId;
+	}
+
+	ZSPACE_INLINE void zObjArc::getRawRadius(double _radius)
+	{
+		_radius = radius;
+	}
+
+	ZSPACE_INLINE void zObjArc::getRawAngleRadian(double _angle)
+	{
+		_angle = angle;
+	}
+
+	ZSPACE_INLINE void zObjArc::getRawPlane(zObjPlane _oPlane)
+	{
+		_oPlane = oPlane;
 	}
 
 	//---- OVERRIDE METHODS
@@ -103,7 +143,7 @@ namespace zSpace
 
 		if (displayControlPoints)
 		{
-			displayUtils->drawPoints(&controlPoints[0], controlPointsColor, controlPointWeight, controlPoints.size());
+			displayUtils->drawPoints(&controlPoints[0], controlPointsColor, controlPointsWeight, controlPoints.size());
 			displayUtils->drawCurve(&controlPoints[0], controlPolyColor, controlPolyWeight, controlPoints.size(), false);
 		}
 

--- a/cpp/source/zInterOp/objects/zObjCurve.cpp
+++ b/cpp/source/zInterOp/objects/zObjCurve.cpp
@@ -1,0 +1,174 @@
+// This file is part of zspace, a simple C++ collection of geometry data-structures & algorithms, 
+// data analysis & visualization framework.
+//
+// Copyright (C) 2023 ZSPACE 
+// 
+// This Source Code Form is subject to the terms of the MIT License 
+// If a copy of the MIT License was not distributed with this file, You can 
+// obtain one at https://opensource.org/licenses/MIT.
+//
+// Author : Ling Mao <Ling.Mao@zaha-hadid.com>
+//
+
+
+#include<headers/zInterOp/objects/zObjCurve.h>
+
+namespace zSpace
+{
+	//---- CONSTRUCTOR
+
+	ZSPACE_INLINE zObjCurve::zObjCurve()
+	{
+
+#if defined (ZSPACE_UNREAL_INTEROP) || defined (ZSPACE_MAYA_INTEROP) /*|| defined (ZSPACE_RHINO_INTEROP)*/
+		// Do Nothing
+#else
+		displayUtils = nullptr;
+#endif
+
+		displayControlPoints = false;
+		displayCurve = true;
+	}
+
+	//---- DESTRUCTOR
+
+	ZSPACE_INLINE zObjCurve::~zObjCurve() {}
+
+	//---- SET METHODS
+
+	ZSPACE_INLINE void zObjCurve::setDisplayElements(bool _displayControlPoints, bool _displayCurve)
+	{
+		displayControlPoints = _displayControlPoints;
+		displayCurve = _displayCurve;
+	}
+
+	ZSPACE_INLINE void zObjCurve::setDisplayPositions(zPointArray& _positions)
+	{
+		displayPositions = _positions;
+		numDisplayPositions = _positions.size();
+	}
+
+	ZSPACE_INLINE void zObjCurve::setDisplayColor(zColor _displayColor)
+	{
+		displayColor = _displayColor;
+	}
+
+	ZSPACE_INLINE void zObjCurve::setDisplayWeight(double _displayWeight)
+	{
+		displayWeight = _displayWeight;
+	}
+
+	ZSPACE_INLINE void zObjCurve::setDisplayControlPoints(zPointArray& _displayControlPoints)
+	{
+		displayControlPointPositions = _displayControlPoints;
+	}
+
+	ZSPACE_INLINE void zObjCurve::setControlPointWeights(zDoubleArray& _controlPointWeights)
+	{
+		for (int i = 0; i < _controlPointWeights.size(); i++)
+		{
+			on_curve.SetWeight(i, _controlPointWeights[i]);
+		}
+	}
+
+	ZSPACE_INLINE void zObjCurve::setDegree(int _degree)
+	{
+		degree = _degree;
+	}
+
+	ZSPACE_INLINE void zObjCurve::setPeriodic(bool _periodic)
+	{
+		periodic = _periodic;
+	}
+
+	//---- GET METHODS
+
+	ZSPACE_INLINE void zObjCurve::getDisplayPositions(zPointArray& _positions)
+	{
+		_positions = displayPositions;
+	}
+
+	ZSPACE_INLINE int zObjCurve::getNumDisplayPositions()
+	{
+		return numDisplayPositions;
+	}
+
+	ZSPACE_INLINE int zObjCurve::getDegree()
+	{
+		return on_curve.Dimension();
+	}
+
+	ZSPACE_INLINE bool zObjCurve::isPeriodic()
+	{
+		return on_curve.IsPeriodic();
+	}
+
+	ZSPACE_INLINE int zObjCurve::getVBO_ControlPointId()
+	{
+		return VBO_ControlPointId;
+	}
+
+	ZSPACE_INLINE int zObjCurve::getVBO_CurvePointId()
+	{
+		return VBO_CurvePointId;
+	}
+
+	ZSPACE_INLINE int zObjCurve::getVBO_CurveColorId()
+	{
+		return VBO_CurveColorId;
+	}
+
+	//---- OVERRIDE METHODS
+
+	ZSPACE_INLINE void zObjCurve::getBounds(zPoint &minBB, zPoint &maxBB)
+	{
+		coreUtils.getBounds(displayPositions, minBB, maxBB);
+	}
+
+#if defined (ZSPACE_UNREAL_INTEROP) || defined (ZSPACE_MAYA_INTEROP) /*|| defined (ZSPACE_RHINO_INTEROP)*/
+	// Do Nothing
+#else
+	   
+	ZSPACE_INLINE void zObjCurve::draw()
+	{
+		if (displayObject)
+		{
+			drawNurbsCurve();
+		}
+
+		if (displayObjectTransform)
+		{
+			displayUtils->drawTransform(transformationMatrix);
+		}
+	}
+
+	//---- DISPLAY BUFFER METHODS
+
+	ZSPACE_INLINE void zObjNurbsCurve::appendToBuffer()
+	{
+		
+	}
+	
+	//---- PROTECTED DISPLAY METHODS
+
+	ZSPACE_INLINE void zObjNurbsCurve::drawNurbsCurve()
+	{
+		// draw vertex
+		if (displayControlPoints)
+		{
+			displayUtils->drawPoints(&displayControlPointPositions[0], zColor(), 3, displayControlPointPositions.size());
+			displayUtils->drawCurve(&displayControlPointPositions[0], zColor(), 1, displayControlPointPositions.size(), periodic);
+		}
+
+
+		// draw edges
+		if (displayCurve)
+		{
+			displayUtils->drawCurve(&displayPositions[0], displayColor, displayWeight, displayPositions.size(),periodic);
+		}
+
+	
+	}
+
+#endif // !ZSPACE_UNREAL_INTEROP
+}

--- a/cpp/source/zInterOp/objects/zObjPlane.cpp
+++ b/cpp/source/zInterOp/objects/zObjPlane.cpp
@@ -48,6 +48,13 @@ namespace zSpace
 		displayRectangleScale = _displayRectangleScale;		
 	}
 
+	ZSPACE_INLINE void zObjPlane::setDisplayColor(zColorArray _displayColorArray)
+	{
+		displayColor.clear();
+		displayColor = _displayColorArray;
+	}
+
+
 	//---- GET METHODS
 	
 	ZSPACE_INLINE zPlane zObjPlane::getPlaneMatrix()
@@ -92,6 +99,26 @@ namespace zSpace
 		planeArray.push_back(0);
 		planeArray.push_back(1);
 		return planeArray;
+	}
+
+	ZSPACE_INLINE void zObjPlane::getRawOrigin(zPoint& _origin)
+	{
+		_origin = origin;
+	}
+
+	ZSPACE_INLINE void zObjPlane::getRawXAxis(zVector& _xAxis)
+	{
+		_xAxis = xAxis;
+	}
+
+	ZSPACE_INLINE void zObjPlane::getRawYAxis(zVector& _yAxis)
+	{
+		_yAxis = yAxis;
+	}
+
+	ZSPACE_INLINE void zObjPlane::getRawNormal(zVector& _Normal)
+	{
+		_Normal = normal;
 	}
 
 	//---- OVERRIDE METHODS
@@ -142,15 +169,31 @@ namespace zSpace
 		// draw vertex
 		if (displayRectangle)
 		{
-			zPoint p0 = origin + (xAxis + yAxis) * displayAxisScale;
-			zPoint p1 = origin + (xAxis - yAxis) * displayAxisScale;
-			zPoint p2 = origin - (xAxis + yAxis) * displayAxisScale;
-			zPoint p3 = origin - (xAxis - yAxis) * displayAxisScale;
+			int divisionNum = 10;
+			zPointArray pU1;
+			zPointArray pU2;
+			zPointArray pV1;
+			zPointArray pV2;
 
-			displayUtils->drawLine(p0, p1, zColor(), 1);
-			displayUtils->drawLine(p1, p2, zColor(), 1);
-			displayUtils->drawLine(p2, p3, zColor(), 1);
-			displayUtils->drawLine(p3, p0, zColor(), 1);
+			zPoint p0 = origin + (xAxis + yAxis) * displayRectangleScale;
+			zPoint p1 = origin + (xAxis - yAxis) * displayRectangleScale;
+			zPoint p2 = origin - (xAxis + yAxis) * displayRectangleScale;
+			zPoint p3 = origin - (xAxis - yAxis) * displayRectangleScale;
+
+			for (int i = 0; i <= divisionNum; i++)
+			{
+				pU1.push_back(p0 * i / divisionNum + p1 * (divisionNum - i) / divisionNum);
+				pU2.push_back(p3 * i / divisionNum + p2 * (divisionNum - i) / divisionNum);
+				pV1.push_back(p1 * i / divisionNum + p2 * (divisionNum - i) / divisionNum);
+				pV2.push_back(p0 * i / divisionNum + p3 * (divisionNum - i) / divisionNum);
+			}
+					
+			for (int i = 0; i <= divisionNum; i++)
+			{
+				displayUtils->drawLine(pU1[i], pU2[i], zColor(), 1);
+				displayUtils->drawLine(pV1[i], pV2[i], zColor(), 1);
+			}
+			
 		}
 	}
 

--- a/cpp/source/zInterface/functionsets/zFnGraphDynamics.cpp
+++ b/cpp/source/zInterface/functionsets/zFnGraphDynamics.cpp
@@ -99,7 +99,7 @@ namespace zSpace
 			p.particle = zParticle(*v.getRawPosition(), fixed);
 			particlesObj.push_back(p);
 
-			if (!fixed) setVertexColor(zColor(0, 0, 1, 1));
+			//if (!fixed) setVertexColor(zColor(0, 0, 1, 1));
 		}
 
 		/*for (int i = 0; i < particlesObj.size(); i++)


### PR DESCRIPTION
010224_Pushed_zCore_ zFnPlane/arc
Update:
added ZSPACE_USD_INTEROP override methods in zFnPlane/arc/nurbsCurve
refined API annotations in zFnPlane/arc
updated set/get methods in zObjPlane/arc
added zFnPlane divisionNum in the draw method
Issue fixed:
Fixed wrong zFnTypes in zFnPlane
Fixed wrong calling of scale factors in zFnPlane
Update the co-linearity condition in create method